### PR TITLE
Use built wheel packages for pywebview and typing_extensions

### DIFF
--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -25,20 +25,22 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/37/0b/708f73f56e753c95231d80ff095c74f51e26f4407349df896d0b32a6cd35/pywebview-4.4.tar.gz",
-            "sha256": "35d6e907e1b78dfc371f6b776ef66029a13e07a95120700799262118654a9fa7",
+            "url": "https://files.pythonhosted.org/packages/a5/16/a42a05fbf39a5f285f28f496a63b0bc7f6276b41d07caa4366e057b20d1b/pywebview-4.4-py3-none-any.whl",
+            "sha256": "32b3d4481f79fa434db4a9055a2f705636055924a5389a6763994a88064dd59e",
             "x-checker-data": {
                 "type": "pypi",
-                "name": "pywebview"
+                "name": "pywebview",
+                "packagetype": "bdist_wheel"
             }
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/1f/7a/8b94bb016069caa12fc9f587b28080ac33b4fbb8ca369b98bc0a4828543e/typing_extensions-4.8.0.tar.gz",
-            "sha256": "df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef",
+            "url": "https://files.pythonhosted.org/packages/24/21/7d397a4b7934ff4028987914ac1044d3b7d52712f30e2ac7a2ae5bc86dd0/typing_extensions-4.8.0-py3-none-any.whl",
+            "sha256": "8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0",
             "x-checker-data": {
                 "type": "pypi",
-                "name": "typing_extensions"
+                "name": "typing_extensions",
+                "packagetype": "bdist_wheel"
             }
         }
     ]


### PR DESCRIPTION
The flatpak-external-data-checker's PyPI checker checks for source package ("sdist" package type) by default. [1]

However, flatpak-builder cannot not find a version that satisfies the requirement pywebview when it builds and installs from pywebview's source package. And, shows the error:

Discarding file:///run/build/python3-pywebview/pywebview-4.4.tar.gz: Requested pywebview from file:///run/build/python3-pywebview/pywebview-4.4.tar.gz has inconsistent version: expected '4.4', but metadata has '0.0.0'
ERROR: Could not find a version that satisfies the requirement pywebview (from versions: 4.4)
ERROR: No matching distribution found for pywebview

So, this commit makes it install built wheel packages for pywebview and typing_extensions directly by setting the packagetype as "bdist_wheel".

[1]: https://github.com/flathub/flatpak-external-data-checker#pypi-checker